### PR TITLE
Use explict aosp upstream link

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <remote  name="aosp"
-           fetch=".."
+           fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/" />
   <default revision="refs/tags/android-13.0.0_r49"
            remote="aosp"


### PR DESCRIPTION
Looks like latest repo needs it otherwise it will use `..` with github links.